### PR TITLE
fix: handle SSE [DONE] terminator, empty keep-alives, and comment lines

### DIFF
--- a/ovos_solver_openai_persona/engines.py
+++ b/ovos_solver_openai_persona/engines.py
@@ -210,8 +210,10 @@ class OpenAIChatCompletionsSolver(ChatMessageSolver):
         for chunk in s.post(self.api_url, headers=headers,
                             stream=True, data=json.dumps(payload)).iter_lines():
             if chunk:
-                chunk = chunk.decode("utf-8")
-                chunk = json.loads(chunk.split("data: ", 1)[-1])
+                chunk = chunk.decode("utf-8").split("data: ", 1)[-1].strip()
+                if not chunk or chunk == "[DONE]":
+                    continue
+                chunk = json.loads(chunk)
                 if "error" in chunk and "message" in chunk["error"]:
                     LOG.error("API returned an error: " + chunk["error"]["message"])
                     break

--- a/ovos_solver_openai_persona/engines.py
+++ b/ovos_solver_openai_persona/engines.py
@@ -209,21 +209,25 @@ class OpenAIChatCompletionsSolver(ChatMessageSolver):
         }
         for chunk in s.post(self.api_url, headers=headers,
                             stream=True, data=json.dumps(payload)).iter_lines():
-            if chunk:
-                chunk = chunk.decode("utf-8").split("data: ", 1)[-1].strip()
-                if not chunk or chunk == "[DONE]":
-                    continue
-                chunk = json.loads(chunk)
-                if "error" in chunk and "message" in chunk["error"]:
-                    LOG.error("API returned an error: " + chunk["error"]["message"])
-                    break
-                if chunk["choices"][0].get("finish_reason"):
-                    break
-                if "content" not in chunk["choices"][0]["delta"]:
-                    continue
-                text = chunk["choices"][0]["delta"]["content"]
-                if text is not None:
-                    yield text
+            if not chunk:
+                continue
+            line = chunk.decode("utf-8")
+            if not line.startswith("data: "):
+                continue  # SSE comment (':') or non-data field; ignore per spec
+            data_part = line[len("data: "):].strip()
+            if not data_part or data_part == "[DONE]":
+                continue
+            chunk = json.loads(data_part)
+            if "error" in chunk and "message" in chunk["error"]:
+                LOG.error("API returned an error: " + chunk["error"]["message"])
+                break
+            if chunk["choices"][0].get("finish_reason"):
+                break
+            if "content" not in chunk["choices"][0]["delta"]:
+                continue
+            text = chunk["choices"][0]["delta"]["content"]
+            if text is not None:
+                yield text
 
     def get_chat_history(self, system_prompt=None):
         """


### PR DESCRIPTION
## What

`OpenAIChatCompletionsSolver.stream_chat_utterances` (engines.py) crashes
mid-stream on spec-compliant SSE responses from OpenAI-compatible backends.

## Why

OpenAI-spec SSE chat-completions streams contain three line types that the
prior code didn't tolerate:

1. `data: [DONE]` terminator (every response).
2. Empty `data: ` keep-alives.
3. Comment lines starting with `:` (per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation),
   any line whose field name is empty is a comment and must be ignored).
   OpenRouter, for example, prefixes every streaming response with
   `: OPENROUTER PROCESSING` as a keep-alive.

All three failed `json.loads` with `Expecting value: line 1 column 1 (char 0)`,
killing the solver before it returned the assistant's reply.

Reproduced against OpenRouter (`anthropic/claude-sonnet-4.6`); the
spec-conformant terminator and comment-line behavior mean this also affects
OpenAI, LM Studio, Ollama, and any other OpenAI-compatible backend that
follows the SSE spec.

## How

Two small patches on this branch:

1. Strip the `data: ` prefix once, skip if the remainder is empty or `[DONE]`,
   then `json.loads`.
2. Be stricter: only parse lines that actually begin with `data: `; skip
   anything else (covers `:` comment lines and any future non-`data` fields).

```python
if not chunk:
    continue
line = chunk.decode("utf-8")
if not line.startswith("data: "):
    continue  # SSE comment (':') or non-data field; ignore per spec
data_part = line[len("data: "):].strip()
if not data_part or data_part == "[DONE]":
    continue
chunk = json.loads(data_part)
```

No behavior change for valid chunks.

## Tested

Running on a Raspberry Pi 5 with `ovos-core` 2.1.1 + this plugin pinned to
the branch; full wake-word -> STT -> persona -> TTS round-trip completes
against OpenRouter where the unpatched version errored with `Expecting
value: line 1 column 1 (char 0)` on every utterance.