### PR TITLE
fix(ci): correct release version_file path to ovos_openai_plugin

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       branch: 'master'
-      version_file: 'ovos_solver_openai_persona/version.py'
+      version_file: 'ovos_openai_plugin/version.py'
       publish_pypi: true
       sync_dev: true
       publish_release: true

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
     with:
       branch: 'dev'
-      version_file: 'ovos_solver_openai_persona/version.py'
+      version_file: 'ovos_openai_plugin/version.py'
       update_changelog: true
       publish_prerelease: true
       propose_release: true


### PR DESCRIPTION
The opm-agents migration renamed the package `ovos_solver_openai_persona` → `ovos_openai_plugin`, but `release_workflow.yml` and `publish_stable.yml` still pointed `version_file` at the old path. The publish-alpha job has failed on every `dev` merge since (including #54), so no alpha has been published.

This corrects the path in both workflows. On merge, the alpha publish will fire correctly and release the opm-agents code (PersonaServerRAGMemory, `OpenAIChatEngine`) so downstreams (ovos-agentic-loop, ovos-persona-server) can pin a published version instead of a git-ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to ensure proper version detection during stable and alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->