### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # <img src='https://raw.githack.com/FortAwesome/Font-Awesome/master/svgs/solid/robot.svg' card_color='#40DBB0' width='50' height='50' style='vertical-align:bottom'/> OVOS OpenAI Plugin
 
-Leverages the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) to provide
-OpenAI-compatible plugins for OpenVoiceOS. Any server exposing the OpenAI `/chat/completions` contract
-(OpenAI, [ollama](https://ollama.com), llama.cpp, vLLM, LocalAI, ...) can be used by pointing `api_url` at its `/v1` base.
+This package uses the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) to
+provide OpenAI-compatible plugins for OpenVoiceOS. It works with any server that exposes the OpenAI
+`/chat/completions` contract, such as OpenAI, [ollama](https://ollama.com), llama.cpp, vLLM, or LocalAI.
+Point `api_url` at the server's `/v1` base to use it.
 
 This package provides:
 
@@ -15,12 +16,12 @@ This package provides:
 | `ovos-lang-detect-openai-plugin` | `opm.lang.detect` | `LanguageDetector` | LLM-backed language detection |
 | `ovos-dialog-transformer-openai-plugin` | `opm.transformer.dialog` | `DialogTransformer` | Rewrite OVOS dialogs just before TTS in [ovos-audio](https://github.com/OpenVoiceOS/ovos-audio) |
 
-> ⚠️ **Breaking change** — solver plugins are [deprecated in ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/365).
+> **Breaking change:** solver plugins are [deprecated in ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/365).
 > This release migrates from the legacy `QuestionSolver`/`ChatMessageSolver` to the new
 > [agents framework](https://github.com/OpenVoiceOS/ovos-plugin-manager) (`AbstractAgentEngine`).
-> The old `ovos-solver-openai-plugin` entry point and the `OpenAIChatCompletionsSolver` /
-> `OpenAIPersonaSolver` classes have been removed. Personas must now reference `ovos-chat-openai-plugin`,
-> and this release requires `ovos-plugin-manager>=2.2.3a1` and `ovos-persona>=0.9.0a1`.
+> The old `ovos-solver-openai-plugin` entry point and the `OpenAIChatCompletionsSolver` and
+> `OpenAIPersonaSolver` classes have been removed. Personas must now reference `ovos-chat-openai-plugin`.
+> This release requires `ovos-plugin-manager>=2.2.3a1` and `ovos-persona>=0.9.0a1`.
 
 ## Install
 
@@ -47,21 +48,21 @@ To create your own persona using an OpenAI-compatible server, create a `.json` i
 }
 ```
 
-> The `solvers` key name is kept for backwards compatibility with persona JSON files; it now accepts
+> The `solvers` key name is kept for backwards compatibility with persona JSON files. It now accepts
 > agent plugin names (chat engines) in addition to legacy solvers.
 
-Then say "Chat with {name_from_json}" to enable it; more details can be found in the
-[ovos-persona](https://github.com/OpenVoiceOS/ovos-persona) README.
+Say "Chat with {name_from_json}" to enable it. See the
+[ovos-persona](https://github.com/OpenVoiceOS/ovos-persona) README for more details.
 
 This plugin also provides a default "Remote LLama" demo persona, pointing to a public server hosted by @goldyfruit.
 
 ## RAG memory
 
-`ovos-openai-rag-memory-plugin` (`PersonaServerRAGMemory`) is a persona **memory
-plugin**: before each turn it searches a vector store on an
+`ovos-openai-rag-memory-plugin` (`PersonaServerRAGMemory`) is a persona memory
+plugin. Before each turn, it searches a vector store on an
 [ovos-persona-server](https://github.com/OpenVoiceOS/ovos-persona-server) and injects
-the retrieved chunks into the conversation context — the persona's chat engine then
-answers. It composes with any chat backend instead of owning the chat round-trip.
+the retrieved chunks into the conversation context. The persona's chat engine then
+answers. This plugin composes with any chat backend instead of owning the chat round-trip.
 
 Set it as the persona's `memory_module`:
 
@@ -82,9 +83,9 @@ Set it as the persona's `memory_module`:
 `inject_mode` selects how retrieved context enters the prompt: `system` (separate
 system message, default), `system_prompt`, `developer`, `user`, or `tool` (a
 synthetic `search_knowledge_base` tool-call result). Retrieval (`max_num_results`,
-`min_score`, `query_mode`) and context formatting are configurable — see the
-`rag_memory` module docstring. Requires `ovos-persona` that passes config to memory
-plugins.
+`min_score`, `query_mode`) and context formatting are configurable. See the
+`rag_memory` module docstring for details. This feature requires an `ovos-persona`
+version that passes config to memory plugins.
 
 ## Dialog Transformer
 
@@ -109,7 +110,7 @@ To enable this plugin, add the following to your `mycroft.conf`:
 }
 ```
 
-> 💡 the dialog will be appended after `rewrite_prompt` for the actual query
+> The actual dialog text is appended after `rewrite_prompt` in the request.
 
 ## Direct Usage
 
@@ -151,10 +152,10 @@ print(summary.summarize("a very long document ..."))
 
 ## Remote Persona / Proxies
 
-You can run any persona behind an OpenAI-compatible server via
-[ovos-persona-server](https://github.com/OpenVoiceOS/ovos-persona-server). This offloads the workload to a
-standalone server, either for performance or to keep API keys in a single safe place. Then just configure this
-plugin to point to your persona server as if it were OpenAI.
+You can run any persona behind an OpenAI-compatible server with
+[ovos-persona-server](https://github.com/OpenVoiceOS/ovos-persona-server). This moves the workload to a
+standalone server, either for performance or to keep API keys in a single safe place. Then configure this
+plugin to point at your persona server as if it were OpenAI.
 
 ## Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ These are forwarded to the Chat Completions request body:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `max_tokens` | int | `300` | Maximum number of tokens to generate. |
-| `temperature` | float | `0.5` | Sampling temperature (0–2). |
+| `temperature` | float | `0.5` | Sampling temperature (0 to 2). |
 | `top_p` | float | `0.2` | Nucleus sampling probability mass. |
 | `frequency_penalty` | float | `0` | Penalize repeated tokens (−2 to 2). |
 | `presence_penalty` | float | `0` | Encourage new topics (−2 to 2). |
@@ -49,3 +49,6 @@ These are forwarded to the Chat Completions request body:
   "temperature": 0.5
 }
 ```
+
+---
+[Home](../README.md) · [Available plugins →](plugins.md)

--- a/docs/persona-integration.md
+++ b/docs/persona-integration.md
@@ -21,7 +21,7 @@ chat agent. Personas are JSON files placed in `~/.config/ovos_persona/`.
 ```
 
 - The `solvers` list contains the **plugin name** to use as the conversational handler. The key is kept
-  for backward compatibility with older persona files; it now accepts agent (chat engine) plugins.
+  for backward compatibility with older persona files. It now accepts agent (chat engine) plugins.
 - A top-level key matching the plugin name holds that plugin's configuration.
 
 Enable it at runtime by saying *"Chat with My Local LLM"*.
@@ -51,3 +51,6 @@ Older personas referencing the removed `ovos-solver-openai-plugin` must be updat
 pipeline, points the chat engine at a local OpenAI-compatible stub server (no network, no key), drives a
 real `recognizer_loop:utterance` through the pipeline, and asserts a `speak` message is produced and the
 user turn is recorded in per-session memory.
+
+---
+[← Available plugins](plugins.md) · [Home](../README.md)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,18 +3,18 @@
 This package ships five plugins, all backed by a shared OpenAI Chat Completions client
 (`ovos_openai_plugin.api.OpenAIChatCompletions`).
 
-## `ovos-chat-openai-plugin` — Chat engine
+## `ovos-chat-openai-plugin`: Chat engine
 
 - **Entry point group:** `opm.agents.chat`
 - **Class:** `ovos_openai_plugin.chat.OpenAIChatEngine` (`ChatEngine`)
 
 A multi-turn conversational agent for ovos-persona. Implements:
 
-- `continue_chat(messages, ...) -> AgentMessage` — full response
-- `stream_tokens(messages, ...)` — raw token stream (not TTS-safe)
-- `stream_sentences(messages, ...)` — complete sentences, buffered via
+- `continue_chat(messages, ...) -> AgentMessage`: full response
+- `stream_tokens(messages, ...)`: raw token stream (not TTS-safe)
+- `stream_sentences(messages, ...)`: complete sentences, buffered via
   [`sentence-stream`](https://pypi.org/project/sentence-stream/) (TTS-safe)
-- `get_response(utterance, ...)` — convenience one-shot helper (from the base class)
+- `get_response(utterance, ...)`: convenience one-shot helper (from the base class)
 
 System prompt handling is controlled by `system_prompt` and `allow_system_prompts`
 (see [configuration](configuration.md)).
@@ -22,14 +22,14 @@ System prompt handling is controlled by `system_prompt` and `allow_system_prompt
 ### Tool / function calling
 
 `OpenAIChatEngine` sets `supports_tools = True`. Pass `ToolBox` object(s) (or OpenAI
-tool dicts) to `continue_chat(..., tools=...)`; the engine exposes them to the model
-and, when the model requests a tool, returns an assistant `AgentMessage` whose
+tool dicts) to `continue_chat(..., tools=...)`. The engine exposes them to the model.
+When the model requests a tool, it returns an assistant `AgentMessage` whose
 `tool_calls` (a list of `ToolCall`) are populated. Feed the results back as
 `MessageRole.TOOL` messages and call again to continue. The
 [`ovos-native-toolcall-loop`](https://github.com/OpenVoiceOS/ovos-agentic-loop)
-engine drives this loop for you; this plugin just needs to be the `brain`.
+engine drives this loop for you. This plugin only needs to be the `brain`.
 
-## `ovos-summarizer-openai-plugin` — Summarizer
+## `ovos-summarizer-openai-plugin`: Summarizer
 
 - **Entry point group:** `opm.agents.summarizer`
 - **Class:** `ovos_openai_plugin.summarizer.OpenAISummarizer` (`SummarizerEngine`)
@@ -37,7 +37,7 @@ engine drives this loop for you; this plugin just needs to be the `brain`.
 Summarizes a document via `summarize(document, lang=None) -> str`. The prompt is built from
 `prompt_template` (must contain `{content}`).
 
-## `ovos-translate-openai-plugin` — Translator
+## `ovos-translate-openai-plugin`: Translator
 
 - **Entry point group:** `opm.lang.translate`
 - **Class:** `ovos_openai_plugin.translate.OpenAITextTranslator` (`LanguageTranslator`)
@@ -46,24 +46,27 @@ Summarizes a document via `summarize(document, lang=None) -> str`. The prompt is
 names (via `langcodes`) before being inserted into the prompt. If `target` is omitted, the configured
 `lang` from OVOS configuration is used. If `source` is omitted, the model auto-detects it.
 
-## `ovos-lang-detect-openai-plugin` — Language detector
+## `ovos-lang-detect-openai-plugin`: Language detector
 
 - **Entry point group:** `opm.lang.detect`
 - **Class:** `ovos_openai_plugin.translate.OpenAITextLangDetector` (`LanguageDetector`)
 
-`detect(text) -> str` returns a standardized BCP-47 tag; `detect_probs(text) -> Dict[str, float]`
+`detect(text) -> str` returns a standardized BCP-47 tag. `detect_probs(text) -> Dict[str, float]`
 returns `{lang: 1.0}`.
 
-## `ovos-dialog-transformer-openai-plugin` — Dialog transformer
+## `ovos-dialog-transformer-openai-plugin`: Dialog transformer
 
 - **Entry point group:** `opm.transformer.dialog`
 - **Class:** `ovos_openai_plugin.dialog_transformers.OpenAIDialogTransformer` (`DialogTransformer`)
 
 Rewrites dialog text just before TTS. `transform(dialog, context) -> (text, context)`. The rewrite
-prompt comes from `context["prompt"]` or the configured `rewrite_prompt`; if neither is set the dialog
+prompt comes from `context["prompt"]` or the configured `rewrite_prompt`. If neither is set, the dialog
 is returned unchanged.
 
 ## Demo persona
 
 The `opm.plugin.persona` entry point `Remote Llama` exposes a ready-made persona
 (`ovos_openai_plugin.LLAMA_DEMO`) pointed at a public OpenAI-compatible LLama server.
+
+---
+[← Configuration reference](configuration.md) · [Home](../README.md) · [Persona integration →](persona-integration.md)


### PR DESCRIPTION
Rewrites README.md and the three docs/*.md pages in Simplified Technical English for clarity: shorter sentences, active voice, and no marketing language, while keeping every fact, code block, and link. Adds a navigation footer to the docs pages linking back to README and between neighboring pages.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified support for OpenAI-compatible servers and remote personas/proxies.
  - Documented the migration from solver plugins to agent plugins, including backward compatibility.
  - Expanded guidance on persona configuration, RAG memory behavior, and dialog transformation requests.
  - Improved configuration and plugin documentation formatting, navigation links, and terminology consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->