### PR TITLE
fix: e2e persona test asserts on legacy 'speak' instead of canonical ovos.utterance.speak

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ test = [
     "pytest>=7.0.0,<9",
     "pytest-timeout>=2.0.0",
     "ovos-persona>=0.9.0a1",
+    "ovos-spec-tools",
     "fastapi",
     "uvicorn",
 ]

--- a/test/end2end/test_e2e_persona_pipeline.py
+++ b/test/end2end/test_e2e_persona_pipeline.py
@@ -29,6 +29,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session, SessionManager
+from ovos_spec_tools.messages import SpecMessage
 
 from ovoscope import (
     PERSONA_PIPELINE,
@@ -213,14 +214,14 @@ class TestOpenAIPersonaSpeaksThroughPipeline:
         messages = _drive_utterance(mc, sess, "who are you", timeout=30)
 
         msg_types = [m.msg_type for m in messages]
-        speak_msgs = [m for m in messages if m.msg_type == "speak"]
+        speak_msgs = [m for m in messages if m.msg_type == SpecMessage.SPEAK]
 
         assert speak_msgs, (
-            f"Expected at least one 'speak' message; got msg_types: {msg_types}"
+            f"Expected at least one '{SpecMessage.SPEAK}' message; got msg_types: {msg_types}"
         )
         spoken = speak_msgs[0].data.get("utterance", "")
         assert spoken.strip(), (
-            f"'speak' message had an empty utterance; data={speak_msgs[0].data}"
+            f"'{SpecMessage.SPEAK}' message had an empty utterance; data={speak_msgs[0].data}"
         )
 
     def test_spoken_text_matches_stub_reply(self, mc):
@@ -232,7 +233,7 @@ class TestOpenAIPersonaSpeaksThroughPipeline:
         spoken = " ".join(
             m.data.get("utterance", "")
             for m in messages
-            if m.msg_type == "speak"
+            if m.msg_type == SpecMessage.SPEAK
         )
         assert "SrvBot" in spoken, (
             f"Expected the stub reply in spoken output, got: {spoken!r}"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Root cause

The ovoscope e2e job on #60 (and presumably every PR touching dev) fails
`test/end2end/test_e2e_persona_pipeline.py` with:

```
AssertionError: Expected at least one 'speak' message; got msg_types: [..., 'ovos.utterance.speak', ...]
```

This looked like the persona pipeline never speaks (empty `speak` messages /
possible `IndexError` in the query handler), but reproducing locally (fresh
clone, throwaway `uv venv`, `uv pip install --pre -e ".[test]"`) shows the
pipeline *does* speak — it just now emits the OVOS-PIPELINE-1 §9.6 canonical
topic `SpecMessage.SPEAK` = `"ovos.utterance.speak"`
(`ovos_workshop/skills/ovos.py:speak()`, ovos-workshop 9.3.8a1), not the
legacy `"speak"` string this test still checks for. No `IndexError` was
observed anywhere in the captured messages or logs; `persona:query` handling
in `ovos_persona` and the chat engine in this repo both work correctly.

So the bug is not in `ovos-openai-plugin` or `ovos-persona` — it's that this
repo's own e2e test predates the message-type migration to `ovos.utterance.speak`
in `ovos-spec-tools`/`ovos-workshop`.

## Fix

- `test/end2end/test_e2e_persona_pipeline.py`: assert on
  `ovos_spec_tools.messages.SpecMessage.SPEAK` instead of the literal `"speak"`.
- `pyproject.toml`: add `ovos-spec-tools` to the `test` extra explicitly
  (previously only pulled in transitively).

## Verification

- RED: fresh clone, throwaway `uv venv`, `uv pip install --pre -e ".[test]"`,
  `pytest test/end2end/test_e2e_persona_pipeline.py` against unpatched dev —
  2 of 3 tests fail with the message above.
- GREEN: same steps on this branch — `3 passed`.

Opened as draft, not merging — no merge grant for this repo.

---

> 🤖 Independent review added by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Independent review

**Verified against current source (downloaded live wheels, not memory):**
- `ovos-workshop` 9.3.9a1 `ovos_workshop/skills/ovos.py::speak()` does emit `SpecMessage.SPEAK`, confirmed by extracting the wheel and reading the source directly — `m = message.forward(SpecMessage.SPEAK, data) ...`.
- `ovos-spec-tools` 1.6.3a1 `ovos_spec_tools/messages.py` confirms `SpecMessage.SPEAK = "ovos.utterance.speak"` — matches the PR's claim exactly, and matches the canonical `<skill_id>:<intent>`-style dispatch-spec naming convention this campaign is sweeping toward (not the legacy suffixed/literal string).
- Diff is genuinely test-only: `pyproject.toml` (adds `ovos-spec-tools` to the `test` extra — a test dependency, not a src dependency) and `test/end2end/test_e2e_persona_pipeline.py` only. No file under the plugin's `src`/package root is touched.
- Direction check: PR's own RED/GREEN evidence (2/3 fail pre-fix with literal `'speak'` message-type assertion, 3/3 pass post-fix) is consistent with what the source confirms — the *producer* changed message type, the *test* was stale, not the other way around. This is not masking a real behavior gap; the underlying speak-pipeline behavior is unchanged and correct.
- CI green across Python 3.10–3.14, ovoscope, lint, license, coverage. Draft PR — CodeRabbit review skipped (draft-detection), no findings to cross-check.

**Issue list:** none.

**Verdict: MERGE**
**Safe for the human to merge? Yes — confirmed test-only, confirmed against live current-source wheels that the new assertion matches real producer behavior, correct RED/RED-to-GREEN direction, CI green.**
