### PR TITLE
fix: allow ovos-config 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "requests",
     "ovos-plugin-manager>=2.7.0a1,<3.0.0",
     "ovos-utils>=0.3.5,<1.0.0",
-    "ovos-config>=0.2.0,<1.0.0",
+    "ovos-config>=0.2.0,<3.0.0",
     "sentence-stream>=1.0.0,<2.0.0",
     "langcodes[data]",
 ]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

## The bug

`pyproject.toml` pinned `ovos-config>=0.2.0,<1.0.0`. ovos-config's versioning jumped from 0.x straight to 2.x (there is no 1.x line), and current ovos-core requires `ovos-config>=2.1.4a5`. So the `<1.0.0` cap makes this plugin uninstallable alongside a current ovos-core: a normal `uv pip install ovos-openai-plugin` drags ovos-config **down** to 0.4.6, which violates ovos-core's floor and breaks a working stack. This was verified on a live deployment (installing the agent downgraded ovos-config and broke ovos-core until pinned back).

The plugin only uses ovos-config's stable `Configuration()` API, unchanged across 0.x and 2.x, so widening the cap is safe. One-line change, floor preserved: `<1.0.0` → `<3.0.0`.

## Why this also fixes the test suite

Before this change the `[test]` extra was itself unresolvable — it pulls ovos-core/ovos-persona, which require ovos-config 2.x, while the runtime dep capped ovos-config `<1.0.0`. With the fix the suite resolves and **50 of 52 tests pass** (verified locally against ovos-config 2.3.8a2).

## The 2 remaining e2e failures are not from this change

`test_e2e_persona_pipeline.py::test_pipeline_produces_speak` / `::test_spoken_text_matches_stub_reply` fail only because the harness resolves **ovos-core 3.0.4a1**, where the persona emits `ovos.utterance.speak` and it is not converted to a `speak` message in the e2e path. On **ovos-core 2.6.4a1** the same persona produces a real `speak` (verified live on a running deployment answering "capital of portugal" → "Lisbon…"). So these two are an ovos-core 3.x persona-speak-flow change, tracked separately, not caused by this pin bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility with newer versions of the configuration dependency while retaining support for existing versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->